### PR TITLE
Fix runtime error if length([1]) in taglist function returns none

### DIFF
--- a/arc.hsl
+++ b/arc.hsl
@@ -244,7 +244,8 @@ class ARC
 		if (array_join($result[0]) != $list)
 			return none;
 		$tags = [];
-		for ($i = 0; $i < length($result[1]); $i++)
+		$len = length($result[1]) ?: 0;
+		for ($i = 0; $i < $len; $i++)
 		{
 			if (isset($tags[$result[1][$i]]))
 				return none;


### PR DESCRIPTION
Some (presumably broken) ARC chain/signature can cause a runtime error resulting in a defer:
`Runtime error in EOD flow eod (falling back on defer): Error in file "extras://arc/arc.hsl", on line 247, column 16: Type check error (NUMBER operator< NONE)`